### PR TITLE
Release

### DIFF
--- a/bluewind/pre_setup.py
+++ b/bluewind/pre_setup.py
@@ -8,16 +8,21 @@ def pre_setup():
     subprocess.run(['python', 'manage.py', 'migrate'], check=True)
     subprocess.run(['python', 'manage.py', 'collectstatic', '--noinput'], check=True)
 
-    # first, update the password for the admin user, in case it changed
-    process = subprocess.Popen(
-        ['python', 'manage.py', 'changepassword', os.environ.get('DJANGO_SUPERUSER_PASSWORD')],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        universal_newlines=True
-    )
     # sometimes the environment is new and there is no superuser yet, if that's the case, update it.
     subprocess.run([
         'python', 'manage.py', 'createsuperuser',
         '--noinput'
+    ])
+    email = os.environ.get('DJANGO_SUPERUSER_EMAIL')
+    username = os.environ.get('DJANGO_SUPERUSER_USERNAME')
+    password = os.environ.get('DJANGO_SUPERUSER_PASSWORD')
+    
+    subprocess.run([
+        'python', 'manage.py', 'shell', '-c',
+        f"""from django.contrib.auth import get_user_model;
+User = get_user_model();
+user = User.objects.get(username='{username}');
+user.set_password('{password}');
+user.email = '{email}';
+user.save()"""
     ])

--- a/bluewind/pre_setup.py
+++ b/bluewind/pre_setup.py
@@ -1,3 +1,6 @@
+import os
+
+
 def pre_setup():
     import subprocess
 
@@ -5,8 +8,15 @@ def pre_setup():
     subprocess.run(['python', 'manage.py', 'migrate'], check=True)
     subprocess.run(['python', 'manage.py', 'collectstatic', '--noinput'], check=True)
 
-
-
+    # first, update the password for the admin user, in case it changed
+    process = subprocess.Popen(
+        ['python', 'manage.py', 'changepassword', os.environ.get('DJANGO_SUPERUSER_PASSWORD')],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True
+    )
+    # sometimes the environment is new and there is no superuser yet, if that's the case, update it.
     subprocess.run([
         'python', 'manage.py', 'createsuperuser',
         '--noinput'

--- a/bluewind/settings.py
+++ b/bluewind/settings.py
@@ -337,3 +337,4 @@ SESSION_ENGINE = 'user_sessions.backends.db'
 
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+# dummy change to test ci

--- a/bluewind/wsgi.py
+++ b/bluewind/wsgi.py
@@ -14,6 +14,8 @@ from django.core.wsgi import get_wsgi_application
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'bluewind.settings')
 
 if 'gunicorn' in os.environ.get('SERVER_SOFTWARE', ''):
+    from dotenv import load_dotenv
+    load_dotenv()
     # this hack allows us to run migrations and build static files when the fargate worker starts
     # Why do this? Because it's incredibly simpler than doing it in github actions.
     # We have this if statement to avoid running this code when wsgi is just imported.

--- a/deploy/django_fargate_cdk_stack.py
+++ b/deploy/django_fargate_cdk_stack.py
@@ -115,7 +115,7 @@ class SimpleFargateCdkStack(Stack):
         
         rds_secret = db_instance.secret
         secret_name = f"{self.stack_name}-{env}-django-admin-credentials"
-        email = "admin@bluewind.ai"
+        email = f"{env}-admin@bluewind.ai"
         
         django_superuser_secret = secretsmanager.Secret(
             self, "DjangoAdminSecretCreation",

--- a/deploy/django_fargate_cdk_stack.py
+++ b/deploy/django_fargate_cdk_stack.py
@@ -49,7 +49,7 @@ class SimpleFargateCdkStack(Stack):
                 "instance_type": ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.SMALL),
                 "cpu": 256,
                 "memory_limit_mib": 1024,
-                "desired_count": 2,
+                "desired_count": 1,
                 "cache_policy": cloudfront.CachePolicy.CACHING_OPTIMIZED,
                 "backup_retention": Duration.days(30),
                 "removal_policy": RemovalPolicy.RETAIN,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 41ccaba61c61d841fdea4e3aeb5e4347fe8c6e5e  | 
|--------|--------|

### Summary:
This PR updates Django setup scripts to configure superuser credentials from environment variables, modifies ECS instance count, and includes a dummy change for CI testing.

**Key points**:
- `bluewind/pre_setup.py`: Added logic to set Django superuser credentials from environment variables.
- `bluewind/wsgi.py`: Load environment variables from `.env` when running under Gunicorn.
- `deploy/django_fargate_cdk_stack.py`: Changed ECS `desired_count` to 1; updated superuser email format.
- `bluewind/settings.py`: Added a dummy change to test CI.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->